### PR TITLE
Fix naming issue that comes with wdio-mocha-framework >= v0.5.5

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -55,7 +55,7 @@ class JsonReporter extends events.EventEmitter {
                 const suite = spec.suites[suiteName]
                 const testSuite = {}
 
-                testSuite.name = suiteName
+                testSuite.name = suite.title
                 testSuite.duration = suite._duration
                 testSuite.start = suite.start
                 testSuite.end = suite.end
@@ -79,7 +79,7 @@ class JsonReporter extends events.EventEmitter {
                     const test = suite.tests[testName]
                     const testCase = {}
 
-                    testCase.name = testName
+                    testCase.name = test.title
                     testCase.start = test.start
                     testCase.end = test.end
                     testCase.duration = test.duration


### PR DESCRIPTION
Hi @fijijavis I've noticed some naming problems after I upgraded to `wdio-mocha-framework` >= v0.5.5. It seems like this commit https://github.com/webdriverio/wdio-spec-reporter/commit/1c9b8a96bb83087e3df9a4414abe9cc93bb6d301 caused this as the `wdio-base-reporter` now uses the `uid` as object key.
Using the appropriate key inside the `suite` or `test` Object will resolve this.

Would be great if you could merge this and create a new release.

Thanks
Jan
