### PR TITLE
Add option to combine the resulting JSONS and specify a filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,37 @@ module.exports = {
 };
 ```
 
+It's also possible to combine all the resulting jsons into one.
+
+```js
+// wdio.conf.js
+module.exports = {
+  // ...
+  reporters: ['dot', 'json'],
+  reporterOptions: {
+    outputDir: './',
+    combined: true
+  },
+  // ...
+};
+```
+
+Another option is to configure the resulting filename of the JSON, if combined is set to false or not set a number is added after the file name: wdio-results-1.json etc.
+
+
+```js
+// wdio.conf.js
+module.exports = {
+  // ...
+  reporters: ['dot', 'json'],
+  reporterOptions: {
+    outputDir: './',
+    filename: 'wdio-results'
+  },
+  // ...
+};
+```
+
 ## Sample Output
 ```
 {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ module.exports = {
 };
 ```
 
-Another option is to configure the resulting filename of the JSON, if combined is set to false or not set a number is added after the file name: wdio-results-1.json etc.
+Another option is to configure the resulting filename of the JSON, if combined is set to false or not set a number is added after the file name: wdio-results-0-1.json etc.
 
 
 ```js

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -20,13 +20,24 @@ class JsonReporter extends events.EventEmitter {
 
         const { epilogue } = this.baseReporter
 
+        if(options.combined) {
+            var resultJsons = [];
+        }
+
         this.on('end', () => {
             for (let cid of Object.keys(this.baseReporter.stats.runners)) {
                 const runnerInfo = this.baseReporter.stats.runners[cid]
                 const start = this.baseReporter.stats.start
                 const end = this.baseReporter.stats.end
                 const json = this.prepareJson(start, end, runnerInfo)
-                this.write(runnerInfo, cid, json)
+                if(options.combined) {
+                    resultJsons.push(json);
+                } else {
+                    this.write(json, runnerInfo.sanitizedCapabilities, cid)
+                }
+            }
+            if(options.combined) {
+                this.combineJsons(resultJsons);
             }
             epilogue.call(baseReporter)
         })
@@ -121,14 +132,42 @@ class JsonReporter extends events.EventEmitter {
         return resultSet
     }
 
-    write (runnerInfo, cid, json) {
+    combineJsons (resultJsons) {
+        var resultSet = {}
+        var runnerInfo = resultJsons[0]
+        resultSet.state = {}
+        resultSet.state.passed = 0
+        resultSet.state.failed = 0
+        resultSet.state.skipped = 0
+        resultSet.start = runnerInfo.start
+        resultSet.end = runnerInfo.end
+        resultSet.capabilities = runnerInfo.capabilities
+        resultSet.host = runnerInfo.host
+        resultSet.port = runnerInfo.port
+        resultSet.baseUrl = runnerInfo.baseUrl
+        resultSet.waitForTimeout = runnerInfo.waitForTimeout
+        resultSet.framework = runnerInfo.framework
+        resultSet.mochaOpts = runnerInfo.mochaOpts
+        resultSet.suites = []
+
+        for (const json of resultJsons) {
+            resultSet.suites.push.apply(resultSet.suites, json.suites);
+            resultSet.state.passed += json.state.passed
+            resultSet.state.skipped += json.state.skipped
+            resultSet.state.failed += json.state.failed
+        }
+
+        this.write (resultSet, resultJsons[0].capabilities.browserName)
+    }
+
+    write (json, browserName, cid) {
         if (!this.options || typeof this.options.outputDir !== 'string') {
             return console.log(`Cannot write json report: empty or invalid 'outputDir'.`)
         }
 
         try {
             const dir = path.resolve(this.options.outputDir)
-            const filename = 'WDIO.json.' + runnerInfo.sanitizedCapabilities + '.' + uuid.v1() + '.json'
+            const filename = this.options.filename ? this.options.filename + this.options.combined ? '.json' : `-${cid}.json` : `WDIO.json.${browserName}.${uuid.v1()}.json`
             const filepath = path.join(dir, filename)
             mkdirp.sync(dir)
             fs.writeFileSync(filepath, JSON.stringify(json))

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -167,7 +167,7 @@ class JsonReporter extends events.EventEmitter {
 
         try {
             const dir = path.resolve(this.options.outputDir)
-            const filename = this.options.filename ? this.options.filename + this.options.combined ? '.json' : `-${cid}.json` : `WDIO.json.${browserName}.${uuid.v1()}.json`
+            const filename = this.options.filename ? this.options.filename + (this.options.combined ? '.json' : `-${cid}.json`) : `WDIO.json.${browserName}.${uuid.v1()}.json`
             const filepath = path.join(dir, filename)
             mkdirp.sync(dir)
             fs.writeFileSync(filepath, JSON.stringify(json))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-json-reporter",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A WebdriverIO plugin. Report results in json format.",
   "main": "build/reporter.js",
   "scripts": {


### PR DESCRIPTION
For my CI pipeline I wanted to use the wdio-json-reporter, but I ran into the issue that it's only able to spit out one json for each spec file. In order to work properly in my CI pipeline I need one resulting JSON. I could fix this in the wrapper code, but I think it makes more sense in order to do it in the reporter itself.

It should also be possible in my opinion to specify a filename (also a requirement for my pipeline ^^) instead of a standard one.