### PR TITLE
Tag support added to the reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,19 @@ module.exports = {
   "suites": [
     {
       "name": "sample test suite number 1",
+      "tags":[
+        "@sample-tag1",
+        "@sample-tag2"
+      ],
       "duration": 12572,
       "start": "2016-05-04T13:06:01.701Z",
       "end": "2016-05-04T13:06:14.273Z",
       "tests": [
         {
           "name": "@Smoke-Sample test number 1",
+          "tags":[
+            "@sample-tag"
+          ],
           "start": "2016-05-04T13:06:01.701Z",
           "end": "2016-05-04T13:06:08.162Z",
           "duration": 6461,
@@ -143,6 +150,9 @@ module.exports = {
         },
         {
           "name": "@Smoke-Sample test number 2",
+          "tags":[
+            "@sample-tag"
+          ],
           "start": "2016-05-04T13:06:08.471Z",
           "end": "2016-05-04T13:06:13.845Z",
           "duration": 5374,
@@ -196,12 +206,17 @@ module.exports = {
     },
     {
       "name": "sample test suite number 2",
+      "tags":[
+      ],
       "duration": 25987,
       "start": "2016-05-04T13:16:01.701Z",
       "end": "2016-05-04T13:16:24.273Z",
       "tests": [
         {
           "name": "@Smoke-Sample test number 3",
+          "tags":[
+            "@sample-tag"
+          ],
           "start": "2016-05-04T13:06:11.701Z",
           "end": "2016-05-04T13:06:18.162Z",
           "duration": 6461,
@@ -209,6 +224,10 @@ module.exports = {
         },
         {
           "name": "@Smoke-Sample test number 4",
+          "tags":[
+            "@sample-tag1",
+            "@sample-tag2"
+          ],
           "start": "2016-05-04T13:06:18.471Z",
           "end": "2016-05-04T13:06:23.845Z",
           "duration": 5374,

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -17,12 +17,20 @@ class JsonReporter extends events.EventEmitter {
         this.baseReporter = baseReporter
         this.config = config
         this.options = options
+        this.tags = {}
 
         const { epilogue } = this.baseReporter
 
         if(options.combined) {
             var resultJsons = [];
         }
+
+        this.on('suite:start', (test) => {
+            this.tags[test.title] = []
+            test.tags.forEach((element, index) => {
+                this.tags[test.title][index] = element.name
+            });
+        })
 
         this.on('end', () => {
             for (let cid of Object.keys(this.baseReporter.stats.runners)) {
@@ -69,6 +77,9 @@ class JsonReporter extends events.EventEmitter {
                 const testSuite = {}
 
                 testSuite.name = suite.title
+                if (testSuite.name in this.tags) {
+                    testSuite.tags = this.tags[testSuite.name]
+                }
                 testSuite.duration = suite._duration
                 testSuite.start = suite.start
                 testSuite.end = suite.end


### PR DESCRIPTION
The tests tags are included now into the report. E.g. if the test looks like that:

> @a_new_tag
> Scenario: Exemplary test
> ...

the report would contain:
```
...
...
{  
         "name":"Exemplary test",
         "tags":[  
            "@a_new_tag"
         ],
...
...
```