### PR TITLE
Add merge script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,37 @@ reporters: [
 ],
 ```
 
+## Result Files
+With WDIO v5, reporting has moved from a centralized process to one that is handled by each of the "sessions" spun up for parallel test execution.  
+This change helped reduce the amount of chatter during WDIO test execution and thus improved performance.  The downside is we are no longer able 
+to get a single report for ALL test execution.  Consider the following:
+
+2 suites of tests configured to run in 2 browsers:
+
+* WDIO v4: 1 json file with execution results
+* WDIO v5: 4 json files with execution results
+
+
+`wdio-json-reporter` provides a utility function to merge the multiple json files into a single file.  Follow the steps below to take advantage of the utility.
+
+1) Create a small node script
+```javascript
+const mergeResults = require('wdio-json-reporter/mergeResults')
+mergeResults()
+```
+
+2) Call node script from command line and pass 2 arguments
+
+* <RESULTS_DIR>: Directory where results files are written
+* <FILE_REGEX>: Regex pattern for finding `wdio-json-reporter` result files in <RESULTS_DIR>.  This is necessary because multiple reporters produce `json` result files
+
+Example:
+```bash
+node mergeResults.json ./Results "wdio-json-*"
+```
+
+Upon completion, the merge script will output a single json file named `wdio-merged.json` in the provided <RESULTS_DIR>
+
 
 # WDIO v4 Compatibility
 

--- a/mergeResults.js
+++ b/mergeResults.js
@@ -1,0 +1,2 @@
+// make mergeResults available at the root
+module.exports = require('./src/mergeResults')

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "wdio-json-reporter",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A WebdriverIO plugin. Report results in json format.",
   "main": "./src/index.js",
+  "files": [
+    "src",
+    "mergeResults.js"
+  ],
   "scripts": {
     "test": "jest",
     "lint": "eslint ./src test/"

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ class JsonReporter extends WDIOReporter {
                 testSuite.duration = suite._duration
                 testSuite.start = suite.start
                 testSuite.end = suite.end
+                testSuite.sessionId = runner.sessionId
                 testSuite.tests = MapTests(suite.tests)
                 testSuite.hooks = MapHooks(suite.hooks)
 

--- a/src/mergeResults.js
+++ b/src/mergeResults.js
@@ -1,0 +1,52 @@
+const fs = require('fs')
+const path = require('path')
+
+const mergeResults = (...args) => {
+    const dir = process.argv[2]
+    const filePattern = process.argv[3]
+
+    const rawData = getDataFromFiles(dir, filePattern)
+    const mergedResults = mergeData(rawData)
+    writeFile(dir, mergedResults)
+}
+
+function getDataFromFiles (dir, filePattern) {
+    const fileNames = fs.readdirSync(dir).filter(file => file.match(filePattern))
+    const data = []
+
+    fileNames.forEach(fileName => {
+        data.push(JSON.parse(fs.readFileSync(`${dir}/${fileName}`)))
+    })
+
+    return data
+}
+
+function mergeData (rawData) {
+    let mergedResults
+
+    rawData.forEach(data => {
+        if (mergedResults === undefined) {
+            // use the first result so that we have the right shape
+            mergedResults = {}
+            Object.assign(mergedResults, data)
+            mergedResults.capabilities = [mergedResults.capabilities] // make this an array so we can capture all caps
+        } else {
+            mergedResults.suites.push(...data.suites)
+            mergedResults.specs.push(...data.specs)
+            mergedResults.state.passed += data.state.passed
+            mergedResults.state.failed += data.state.failed
+            mergedResults.state.skipped += data.state.skipped
+            mergedResults.capabilities.push(data.capabilities)
+        }
+    })
+
+    return mergedResults
+}
+
+function writeFile (dir, mergedResults) {
+    const fileName = 'wdio-merged.json'
+    const filePath = path.join(dir, fileName)
+    fs.writeFileSync(filePath, JSON.stringify(mergedResults))
+}
+
+module.exports = mergeResults


### PR DESCRIPTION
With WDIO v5 reporter event handling has moved from a consolidated single source to the "sessions" spun up to handle parallel test execution. The benefit is faster execution. The downside is having multiple result files.

This utility will merge all wdio-json-reporter json files into a single file.  