### PR TITLE
Bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-json-reporter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A WebdriverIO plugin. Report results in json format.",
   "main": "./src/index.js",
   "files": [

--- a/src/mapHooks.js
+++ b/src/mapHooks.js
@@ -10,7 +10,7 @@ module.exports = function (suiteHooks) {
         hookResult.title = hook.title
         hookResult.associatedSuite = hook.parent
         hookResult.associatedTest = hook.currentTest
-        hookResult.state = hook.errors.length ? hook.state : 'passed'
+        hookResult.state = hook.errors && hook.errors.length ? hook.state : 'passed'
 
         if (hook.error) {
             if (hook.error.type) {


### PR DESCRIPTION
Guard against `hook.errors` being undefined.  As best as I can tell this might be an issue with differences between how Mocha and Jasmine report errors.