### PR TITLE
feat: handle errors thrown by isolated JSON files

### DIFF
--- a/src/mergeResults.js
+++ b/src/mergeResults.js
@@ -16,7 +16,12 @@ function getDataFromFiles (dir, filePattern) {
     const data = []
 
     fileNames.forEach(fileName => {
-        data.push(JSON.parse(fs.readFileSync(`${dir}/${fileName}`)))
+        try {
+            data.push(JSON.parse(fs.readFileSync(`${dir}/${fileName}`)))
+        } catch (e) {
+            console.error(e)
+            console.log(`${dir}/${fileName} was not included in the merged report due to a parsing error`)
+        }
     })
 
     return data


### PR DESCRIPTION
If one file fails to parse then the whole report isn't output, which is causing us some issues.

Would you be happy to catch the errors and move on to the next file as below?