### PR TITLE
Add a newline character to the JSON output so that separate test runners are not outputting JSON objects next to each other on a single line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ class JsonReporter extends WDIOReporter {
 
     onRunnerEnd (runner) {
         let json = this.prepareJson(runner)
-        this.write(JSON.stringify(json))
+        this.write(`${JSON.stringify(json)}\n`)
     }
 
     prepareJson (runner) {


### PR DESCRIPTION
We have a use case where we are running multiple concurrent sessions. WDIO seems to fire the onRunnerEnd event for all of these runners and then the json reporter mashes them all into one line. 

We were running a datadog agent to pull the json reports, but since they were all on one line it was tripping up datadog. This just separates the reports into new lines as they are written. Other ideas are welcome but this got us where we needed to be.